### PR TITLE
Make apiKey field optional

### DIFF
--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -48,7 +48,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
 
   PlacesAutocompleteWidget(
       {Key? key,
-      this.apiKey,
+      required this.apiKey,
       this.mode = Mode.fullscreen,
       this.hint = 'Search',
       this.overlayBorderRadius,
@@ -71,7 +71,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
       this.headers})
       : super(key: key) {
         if (apiKey == null && proxyBaseUrl == null) {
-          throw 'One of `apiKey` and `proxyBaseUrl` fields is required';
+          throw ArgumentError('One of `apiKey` and `proxyBaseUrl` fields is required');
         }
       }
 
@@ -553,7 +553,7 @@ class _SearchState {
 class PlacesAutocomplete {
   static Future<Prediction?> show(
       {required BuildContext context,
-      String? apiKey,
+      required String? apiKey,
       Mode mode = Mode.fullscreen,
       String? hint = 'Search',
       BorderRadius? overlayBorderRadius,

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -12,7 +12,7 @@ import 'package:listenable_stream/listenable_stream.dart';
 import 'package:rxdart/rxdart.dart';
 
 class PlacesAutocompleteWidget extends StatefulWidget {
-  final String apiKey;
+  final String? apiKey;
   final Mode mode;
   final String? hint;
 
@@ -48,7 +48,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
 
   PlacesAutocompleteWidget(
       {Key? key,
-      required this.apiKey,
+      this.apiKey,
       this.mode = Mode.fullscreen,
       this.hint = 'Search',
       this.overlayBorderRadius,
@@ -69,7 +69,11 @@ class PlacesAutocompleteWidget extends StatefulWidget {
       this.startText,
       this.debounce,
       this.headers})
-      : super(key: key);
+      : super(key: key) {
+        if (apiKey == null && proxyBaseUrl == null) {
+          throw 'One of `apiKey` and `proxyBaseUrl` fields is required';
+        }
+      }
 
   @override
   State<PlacesAutocompleteWidget> createState() {
@@ -549,7 +553,7 @@ class _SearchState {
 class PlacesAutocomplete {
   static Future<Prediction?> show(
       {required BuildContext context,
-      required String apiKey,
+      String? apiKey,
       Mode mode = Mode.fullscreen,
       String? hint = 'Search',
       BorderRadius? overlayBorderRadius,

--- a/lib/src/places_autocomplete_field.dart
+++ b/lib/src/places_autocomplete_field.dart
@@ -38,7 +38,7 @@ class PlacesAutocompleteField extends StatefulWidget {
   /// null.
   const PlacesAutocompleteField({
     Key? key,
-    this.apiKey,
+    required this.apiKey,
     this.controller,
     this.leading,
     this.hint = 'Search',

--- a/lib/src/places_autocomplete_field.dart
+++ b/lib/src/places_autocomplete_field.dart
@@ -38,7 +38,7 @@ class PlacesAutocompleteField extends StatefulWidget {
   /// null.
   const PlacesAutocompleteField({
     Key? key,
-    required this.apiKey,
+    this.apiKey,
     this.controller,
     this.leading,
     this.hint = 'Search',
@@ -84,7 +84,7 @@ class PlacesAutocompleteField extends StatefulWidget {
   /// See also:
   ///
   /// * <https://developers.google.com/places/web-service/autocomplete>
-  final String apiKey;
+  final String? apiKey;
 
   /// The decoration to show around the text field.
   ///

--- a/lib/src/places_autocomplete_form_field.dart
+++ b/lib/src/places_autocomplete_form_field.dart
@@ -44,7 +44,7 @@ class PlacesAutocompleteFormField extends FormField<String> {
   /// and [new PlacesAutocompleteField], the constructor.
   PlacesAutocompleteFormField({
     Key? key,
-    String? apiKey,
+    required String? apiKey,
     this.controller,
     Icon? leading,
     String? initialValue,

--- a/lib/src/places_autocomplete_form_field.dart
+++ b/lib/src/places_autocomplete_form_field.dart
@@ -44,7 +44,7 @@ class PlacesAutocompleteFormField extends FormField<String> {
   /// and [new PlacesAutocompleteField], the constructor.
   PlacesAutocompleteFormField({
     Key? key,
-    required String apiKey,
+    String? apiKey,
     this.controller,
     Icon? leading,
     String? initialValue,


### PR DESCRIPTION
As we use a proxy to request Google APIs the apiKey is added on the proxy itself.
Consequently the apiKey should be optional.

I'm using my fork for now.

Feel free to ask if I'm doing something you don't like !